### PR TITLE
additional health field to monitor failed trigger fires

### DIFF
--- a/provider/health.py
+++ b/provider/health.py
@@ -142,7 +142,8 @@ def getConsumers(consumers):
             'currentState': consumer.currentState(),
             'desiredState': consumer.desiredState(),
             'secondsSinceLastPoll': consumer.secondsSinceLastPoll(),
-            'restartCount': consumer.restartCount()
+            'restartCount': consumer.restartCount(),
+            'failures': consumer.failures()
         }
         consumerReports.append(consumerInfo)
 


### PR DESCRIPTION
additional field in health endpoint keeping count of failed trigger fires. incremented after receiving client errors or after exhausting max number of retries