### PR TITLE
Fix binary encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ In order to create a trigger that reacts when messages are posted to a Message H
 |isJSONData|Boolean (Optional - default=false)|When set to `true` this will cause the provider to attempt to parse the message value as JSON before passing it along as the trigger payload.|
 |isBinaryKey|Boolean (Optional - default=false)|When set to `true` this will cause the provider to encode the key value as Base64 before passing it along as the trigger payload.|
 |isBinaryValue|Boolean (Optional - default=false)|When set to `true` this will cause the provider to encode the message value as Base64 before passing it along as the trigger payload.|
+|wrapBase64Encoding|Boolean (Optional - default=true)|When set to `true` this will insert a newline every 76 characters for Base64 encoded values and keys.|
 
 While this list of parameters may seem daunting, they can be automatically set for you by using the package refresh CLI command:
 


### PR DESCRIPTION
This addresses #269 
Note: I'm not a python coder, so I'm sure there might be better ways to achieve this. 

When encoding binary data (ascii string) as utf with variable length encoding only 7 bits are preserved. The 8th bit has a special meaning to indicate the variable encoding "continuation bit". This will of course corrupt any true binary data that has values larger than 127.

A secondary issue addressed in this MR relates to the base 64 encoding mechanism. The method called previously inserts newline characters in the encoded string every 76 characters, something that's not typically expected in newer encoding libraries. I've added a new flag which allows encoding without newline characters (which I assume is what most people will expect).

Finally, each message is encoded twice in the current implementation, once to retrieve the size and a second time to actually trigger the function. 

This fix has the potential to break existing functions that may rely on the old behavior. I'm not sure how to address that and would appreciate feedback. A new parameter to trigger the fixed binary encoding may be necessary.
