### PR TITLE
Use API key for authentication when username is token

### DIFF
--- a/action/messageHubFeedWeb.js
+++ b/action/messageHubFeedWeb.js
@@ -267,7 +267,7 @@ function checkMessageHubCredentials(params) {
         url: topicURL,
         json: true,
         headers: {
-            'X-Auth-Token': params.username + params.password
+            'X-Auth-Token': params.username.toLowerCase() == "token" ? params.password : params.username + params.password
         }
     };
 


### PR DESCRIPTION
Auth fails when an API key is provided and the username is `token`.