### PR TITLE
Disable triggers for invalid auth when using custom auth handler

### DIFF
--- a/provider/authHandler.py
+++ b/provider/authHandler.py
@@ -38,18 +38,17 @@ class IAMAuth(AuthBase):
         r.headers['Authorization'] = 'Bearer {}'.format(self.__getToken())
         return r
 
-
     def __getToken(self):
         if 'expires_in' not in self.tokenInfo or self.__isRefreshTokenExpired():
             response = self.__requestToken()
-            if response.status_code == 200 and 'access_token' in response.json():
+            if response.ok and 'access_token' in response.json():
                 self.tokenInfo = response.json()
                 return self.tokenInfo['access_token']
             else:
                 raise AuthHandlerException(response)
         elif self.__isTokenExpired():
             response = self.__refreshToken()
-            if response.status_code == 200 and 'access_token' in response.json():
+            if response.ok and 'access_token' in response.json():
                 self.tokenInfo = response.json()
                 return self.tokenInfo['access_token']
             else:

--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -417,10 +417,11 @@ class ConsumerProcess (Process):
                 except requests.exceptions.RequestException as e:
                     logging.error('[{}] Error talking to OpenWhisk: {}'.format(self.trigger, e))
                 except AuthHandlerException as e:
+                    logging.error("[{}] Encountered an exception from auth handler, status code {}").format(self.trigger, e.response.status_code)
+                    self.__dumpRequestResponse(e.response)
+
                     if self.__shouldDisable(e.response.status_code):
                         retry = False
-                        logging.error("[{}] Encountered an exception from auth handler, status code {}").format(self.trigger, e.response.status_code)
-                        self.__dumpRequestResponse(e.response)
                         self.__disableTrigger(e.status_code)
 
                 if retry:

--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -417,10 +417,11 @@ class ConsumerProcess (Process):
                 except requests.exceptions.RequestException as e:
                     logging.error('[{}] Error talking to OpenWhisk: {}'.format(self.trigger, e))
                 except AuthHandlerException as e:
-                    retry = False
-                    logging.error("[{}] Encountered an exception from auth handler, status code {}").format(self.trigger, e.response.status_code)
-                    self.__dumpRequestResponse(e.response)
-                    self.__disableTrigger(e.status_code)
+                    if self.__shouldDisable(e.response.status_code):
+                        retry = False
+                        logging.error("[{}] Encountered an exception from auth handler, status code {}").format(self.trigger, e.response.status_code)
+                        self.__dumpRequestResponse(e.response)
+                        self.__disableTrigger(e.status_code)
 
                 if retry:
                     retry_count += 1

--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -422,7 +422,7 @@ class ConsumerProcess (Process):
 
                     if self.__shouldDisable(e.response.status_code):
                         retry = False
-                        self.__disableTrigger(e.status_code)
+                        self.__disableTrigger(e.response.status_code)
 
                 if retry:
                     retry_count += 1

--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -422,7 +422,7 @@ class ConsumerProcess (Process):
                     self.__dumpRequestResponse(e.response)
                     self.__disableTrigger(e.status_code)
 
-            if retry:
+                if retry:
                     retry_count += 1
 
                     if retry_count <= self.max_retries:


### PR DESCRIPTION
When using a custom auth handler, the provider will encounter an exception when invalid credentials are supplied. The provider then gets stuck in an infinite exception loop since the consumer will restart after every exception.

Example log lines displaying this problem:
```
...Firing trigger with 6 messages 
...Uncaught exception: 'access_token' 
...Consumer stopped without being asked 
```