### PR TITLE
Do not update last canary everytime a database connection attempt occurs

### DIFF
--- a/provider/service.py
+++ b/provider/service.py
@@ -50,6 +50,7 @@ class Service (Thread):
 
     def run(self):
         self.canaryGenerator.start()
+        self.lastCanaryTime = datetime.now()
 
         while True:
             try:
@@ -60,8 +61,6 @@ class Service (Thread):
                 logging.info("Starting changes feed")
                 self.database = Database(timeout=changesFeedTimeout)
                 self.changes = self.database.changesFeed(timeout=changesFeedTimeout, since=self.lastSequence)
-
-                self.lastCanaryTime = datetime.now()
 
                 for change in self.changes:
                     # change could be None because the changes feed will timeout


### PR DESCRIPTION
When the provider continuously encounters network errors from the database, the last canary time is always being set to the current time. This logic prevents monitoring from detecting that the canary has actually gone stale because of the network issues. Instead, only update the canary outside of the database reconnection loop.