### PR TITLE
Use version 1.2.0 of librdkafka

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM python:2.7.16
 RUN apt-get update && apt-get upgrade -y
 
 # install librdkafka
-ENV LIBRDKAFKA_VERSION 1.2.2
+ENV LIBRDKAFKA_VERSION 1.2.0
 RUN git clone --depth 1 --branch v${LIBRDKAFKA_VERSION} https://github.com/edenhill/librdkafka.git librdkafka \
     && cd librdkafka \
     && ./configure \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM python:2.7.16
 RUN apt-get update && apt-get upgrade -y
 
 # install librdkafka
-ENV LIBRDKAFKA_VERSION 1.0.0
+ENV LIBRDKAFKA_VERSION 1.2.2
 RUN git clone --depth 1 --branch v${LIBRDKAFKA_VERSION} https://github.com/edenhill/librdkafka.git librdkafka \
     && cd librdkafka \
     && ./configure \

--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -295,8 +295,7 @@ class ConsumerProcess (Process):
                         'group.id': self.trigger,
                         'default.topic.config': {'auto.offset.reset': 'latest'},
                         'enable.auto.commit': False,
-                        'api.version.request': True,
-                        'enable.sparse.connections': False
+                        'api.version.request': True
                     }
 
             if self.isMessageHub:


### PR DESCRIPTION
Notable fixes since 1.0.0:

`Fix consumer stall when broker connection goes down (issue #2266 introduced in v1.0.0)`
https://github.com/edenhill/librdkafka/releases/tag/v1.0.1

`Consumer: max.poll.interval.ms now correctly handles blocking poll calls, allowing a longer poll timeout than the max poll interval.`
https://github.com/edenhill/librdkafka/releases/tag/v1.1.0
