### PR TITLE
Allow feed to be deleted if trigger does not exist

### DIFF
--- a/action/kafkaFeedWeb.js
+++ b/action/kafkaFeedWeb.js
@@ -47,7 +47,7 @@ function main(params) {
                     // do these in parallel!
                     return Promise.all([
                         db.ensureTriggerIsUnique(validatedParams.triggerName),
-                        verifyTriggerAuth(validatedParams.triggerURL, params.authKey)
+                        verifyTriggerAuth(validatedParams.triggerURL, params.authKey, true)
                     ]);
                 })
                 .then(() => {
@@ -82,7 +82,7 @@ function main(params) {
         } else if (params.__ow_method === "get") {
             const triggerURL = common.getTriggerURL(params.endpoint, params.triggerName);
 
-            return verifyTriggerAuth(triggerURL, params.authKey)
+            return verifyTriggerAuth(triggerURL, params.authKey, true)
                 .then(() => {
                     db = new Database(params.DB_URL, params.DB_NAME);
                     return db.getTrigger(params.triggerName);
@@ -112,7 +112,7 @@ function main(params) {
         } else if (params.__ow_method === "put") {
             const triggerURL = common.getTriggerURL(params.endpoint, params.triggerName);
 
-            return verifyTriggerAuth(triggerURL, params.authKey)
+            return verifyTriggerAuth(triggerURL, params.authKey, true)
                 .then(() => {
                     db = new Database(params.DB_URL, params.DB_NAME);
                     return db.getTrigger(params.triggerName);
@@ -142,7 +142,7 @@ function main(params) {
         } else if (params.__ow_method === "delete") {
             const triggerURL = common.getTriggerURL(params.endpoint, params.triggerName);
 
-            return verifyTriggerAuth(triggerURL, params.authKey)
+            return verifyTriggerAuth(triggerURL, params.authKey, false)
                 .then(() => {
                     db = new Database(params.DB_URL, params.DB_NAME);
                     return db.deleteTrigger(params.triggerName);
@@ -195,9 +195,9 @@ function validateParameters(rawParams) {
     return promise;
 }
 
-function verifyTriggerAuth(triggerURL, apiKey) {
+function verifyTriggerAuth(triggerURL, apiKey, rejectNotFound) {
     var auth = apiKey.split(':');
-    return common.verifyTriggerAuth(triggerURL, { user: auth[0], pass: auth[1] });
+    return common.verifyTriggerAuth(triggerURL, { user: auth[0], pass: auth[1] }, rejectNotFound);
 }
 
 exports.main = main;

--- a/action/lib/common.js
+++ b/action/lib/common.js
@@ -38,7 +38,7 @@ function getTriggerURL(endpoint, triggerName) {
     return url;
 }
 
-function verifyTriggerAuth(triggerURL, auth) {
+function verifyTriggerAuth(triggerURL, auth, rejectNotFound) {
     var options = {
         method: 'GET',
         url: triggerURL,
@@ -52,8 +52,12 @@ function verifyTriggerAuth(triggerURL, auth) {
 
     return request(options)
         .catch(err => {
-            console.log(`Trigger auth error: ${JSON.stringify(err)}`);
-            return Promise.reject({ authError: 'You are not authorized for this trigger.'});
+            if (err.statusCode && err.statusCode === 404 && !rejectNotFound) {
+                return Promise.resolve()
+            } else {
+                console.log(`Trigger auth error: ${JSON.stringify(err)}`);
+                return Promise.reject({ authError: 'You are not authorized for this trigger.'});
+            }
         });
 }
 

--- a/action/messageHubFeedWeb.js
+++ b/action/messageHubFeedWeb.js
@@ -50,7 +50,7 @@ function main(params) {
                     // do these in parallel!
                     return Promise.all([
                         db.ensureTriggerIsUnique(validatedParams.triggerName),
-                        verifyTriggerAuth(validatedParams.triggerURL, params.authKey, params.isIamKey, params.iamUrl),
+                        verifyTriggerAuth(validatedParams.triggerURL, params.authKey, params.isIamKey, params.iamUrl, true),
                         checkMessageHubCredentials(validatedParams)
                     ]);
                 })
@@ -86,7 +86,7 @@ function main(params) {
         } else if (params.__ow_method === "get") {
             const triggerURL = common.getTriggerURL(params.endpoint, params.triggerName);
 
-            return verifyTriggerAuth(triggerURL, params.authKey, params.isIamKey, params.iamUrl)
+            return verifyTriggerAuth(triggerURL, params.authKey, params.isIamKey, params.iamUrl, true)
                 .then(() => {
                     db = new Database(params.DB_URL, params.DB_NAME);
                     return db.getTrigger(params.triggerName);
@@ -119,7 +119,7 @@ function main(params) {
         } else if (params.__ow_method === "put") {
             const triggerURL = common.getTriggerURL(params.endpoint, params.triggerName);
 
-            return verifyTriggerAuth(triggerURL, params.authKey, params.isIamKey, params.iamUrl)
+            return verifyTriggerAuth(triggerURL, params.authKey, params.isIamKey, params.iamUrl, true)
                 .then(() => {
                     db = new Database(params.DB_URL, params.DB_NAME);
                     return db.getTrigger(params.triggerName);
@@ -149,7 +149,7 @@ function main(params) {
         } else if (params.__ow_method === "delete") {
             const triggerURL = common.getTriggerURL(params.endpoint, params.triggerName);
 
-            return verifyTriggerAuth(triggerURL, params.authKey, params.isIamKey, params.iamUrl)
+            return verifyTriggerAuth(triggerURL, params.authKey, params.isIamKey, params.iamUrl, false)
                 .then(() => {
                     db = new Database(params.DB_URL, params.DB_NAME);
                     return db.deleteTrigger(params.triggerName);
@@ -293,12 +293,12 @@ function checkMessageHubCredentials(params) {
         });
 }
 
-function verifyTriggerAuth(triggerURL, apiKey, isIamKey, iamUrl) {
+function verifyTriggerAuth(triggerURL, apiKey, isIamKey, iamUrl, rejectNotFound) {
     if (isIamKey === true) {
         return new itm({ 'iamApikey': apiKey, 'iamUrl': iamUrl }).getToken().then( token => common.verifyTriggerAuth(triggerURL, { bearer: token }));
     } else {
         var auth = apiKey.split(':');
-        return common.verifyTriggerAuth(triggerURL, { user: auth[0], pass: auth[1] });
+        return common.verifyTriggerAuth(triggerURL, { user: auth[0], pass: auth[1] }, rejectNotFound);
     }
 }
 


### PR DESCRIPTION
If for some reason a trigger has been deleted though the associated feed still exists, a user cannot delete the corresponding feed manually.