### PR TITLE
Update existing trigger feeds on create instead of failing

### DIFF
--- a/action/kafkaFeedWeb.js
+++ b/action/kafkaFeedWeb.js
@@ -122,11 +122,11 @@ function main(params) {
                         return resolve(common.webResponse(400, `${params.triggerName} cannot be updated because it is disabled`));
                     }
 
-                    return db.disableTrigger(triggerDoc)
-                    .then(() => db.getTrigger(params.triggerName))
-                    .then(doc => {
-                        return common.performUpdateParameterValidation(params, doc)
-                        .then(updatedParams => db.updateTrigger(doc, updatedParams))
+                    return common.performUpdateParameterValidation(params, triggerDoc)
+                    .then(updatedParams => {
+                        return db.disableTrigger(triggerDoc)
+                        .then(() => db.getTrigger(params.triggerName))
+                        .then(doc => db.updateTrigger(doc, updatedParams));
                     });
                 })
                 .then(() => {

--- a/action/kafkaFeedWeb.js
+++ b/action/kafkaFeedWeb.js
@@ -121,8 +121,13 @@ function main(params) {
                     if (!triggerDoc.status.active) {
                         resolve(common.webResponse(400, `${params.triggerName} cannot be updated because it is disabled`));
                     }
-                    return common.performUpdateParameterValidation(params, triggerDoc)
-                    .then(updatedParams => db.updateTrigger(triggerDoc, updatedParams))
+
+                    return db.disableTrigger(triggerDoc)
+                    .then(() => db.getTrigger(params.triggerName))
+                    .then(doc => {
+                        return common.performUpdateParameterValidation(params, doc)
+                        .then(updatedParams => db.updateTrigger(doc, updatedParams))
+                    });
                 })
                 .then(() => {
                     console.log('successfully updated the trigger');

--- a/action/kafkaFeedWeb.js
+++ b/action/kafkaFeedWeb.js
@@ -119,7 +119,7 @@ function main(params) {
                 })
                 .then(triggerDoc => {
                     if (!triggerDoc.status.active) {
-                        resolve(common.webResponse(400, `${params.triggerName} cannot be updated because it is disabled`));
+                        return resolve(common.webResponse(400, `${params.triggerName} cannot be updated because it is disabled`));
                     }
 
                     return db.disableTrigger(triggerDoc)

--- a/action/lib/Database.js
+++ b/action/lib/Database.js
@@ -64,7 +64,7 @@ module.exports = function(dbURL, dbName) {
                         .then(() => this.getTrigger(params.triggerName))
                         .then(doc => this.updateTrigger(doc, params))
                         .then(result => resolve(result))
-                        .catch(err => reject(`Failed to update existing trigger: ${err.statusCode})`));
+                        .catch(err => reject(err));
                     } else {
                         reject(err);
                     }
@@ -174,6 +174,7 @@ module.exports = function(dbURL, dbName) {
                     }
                 });
             });
-        });
+        })
+        .catch(err => Promise.reject(err));
     };
 };

--- a/action/lib/Database.js
+++ b/action/lib/Database.js
@@ -60,21 +60,11 @@ module.exports = function(dbURL, dbName) {
                 if(err) {
                     if(err.statusCode && err.statusCode === 409) {
                         this.getTrigger(params.triggerName)
-                        .then(() => {
-                            return this.disableTrigger(params.triggerName);
-                        })
-                        .then(() => {
-                            return this.getTrigger(params.triggerName);
-                        })
-                        .then(doc => {
-                            this.updateTrigger(doc, params);
-                        })
-                        .then(() => {
-                            resolve();
-                        })
-                        .catch(err => {
-                            reject(`Failed to update existing trigger: ${err.statusCode})`)
-                        })
+                        .then(() => this.disableTrigger(params.triggerName))
+                        .then(() => this.getTrigger(params.triggerName))
+                        .then(doc => this.updateTrigger(doc, params))
+                        .then(result => resolve(result))
+                        .catch(err => reject(`Failed to update existing trigger: ${err.statusCode})`));
                     } else {
                         reject(err);
                     }

--- a/action/lib/Database.js
+++ b/action/lib/Database.js
@@ -60,7 +60,7 @@ module.exports = function(dbURL, dbName) {
                 if(err) {
                     if(err.statusCode && err.statusCode === 409) {
                         this.getTrigger(params.triggerName)
-                        .then(() => this.disableTrigger(params.triggerName))
+                        .then(doc => this.disableTrigger(doc))
                         .then(() => this.getTrigger(params.triggerName))
                         .then(doc => this.updateTrigger(doc, params))
                         .then(result => resolve(result))

--- a/action/lib/Database.js
+++ b/action/lib/Database.js
@@ -62,7 +62,7 @@ module.exports = function(dbURL, dbName) {
                         this.getTrigger(params.triggerName)
                         .then(doc => this.disableTrigger(doc))
                         .then(() => this.getTrigger(params.triggerName))
-                        .then(doc => this.updateTrigger(doc, params))
+                        .then(doc => this.updateTrigger(params, {_rev: doc._rev}))
                         .then(result => resolve(result))
                         .catch(err => reject(err));
                     } else {
@@ -151,30 +151,25 @@ module.exports = function(dbURL, dbName) {
     }
 
     this.updateTrigger = function(existing, params) {
-        this.disableTrigger(existing)
-        .then(() => this.getTrigger(existing.triggerName))
-        .then(doc => {
-            for (var key in params) {
-                if (params[key] !== undefined) {
-                    doc[key] = params[key];
-                }
+        for (var key in params) {
+            if (params[key] !== undefined) {
+                existing[key] = params[key];
             }
-            var status = {
-                'active': true,
-                'dateChanged': Date.now()
-            };
-            doc.status = status;
+        }
+        var status = {
+            'active': true,
+            'dateChanged': Date.now()
+        };
+        existing.status = status;
 
-            return new Promise((resolve, reject) => {
-                this.db.insert(doc, (err, result) => {
-                    if(err) {
-                        reject(err);
-                    } else {
-                        resolve(result);
-                    }
-                });
+        return new Promise((resolve, reject) => {
+            this.db.insert(existing, (err, result) => {
+                if(err) {
+                    reject(err);
+                } else {
+                    resolve(result);
+                }
             });
-        })
-        .catch(err => Promise.reject(err));
+        });
     };
 };

--- a/action/lib/Database.js
+++ b/action/lib/Database.js
@@ -148,7 +148,7 @@ module.exports = function(dbURL, dbName) {
                 }
             });
         })
-    }
+    };
 
     this.updateTrigger = function(existing, params) {
         for (var key in params) {

--- a/action/messageHubFeedWeb.js
+++ b/action/messageHubFeedWeb.js
@@ -129,11 +129,11 @@ function main(params) {
                         return resolve(common.webResponse(400, `${params.triggerName} cannot be updated because it is disabled`));
                     }
 
-                    return db.disableTrigger(triggerDoc)
-                    .then(() => db.getTrigger(params.triggerName))
-                    .then(doc => {
-                        return common.performUpdateParameterValidation(params, doc)
-                        .then(updatedParams => db.updateTrigger(doc, updatedParams))
+                    return common.performUpdateParameterValidation(params, triggerDoc)
+                    .then(updatedParams => {
+                        return db.disableTrigger(triggerDoc)
+                        .then(() => db.getTrigger(params.triggerName))
+                        .then(doc => db.updateTrigger(doc, updatedParams));
                     });
                 })
                 .then(() => {

--- a/action/messageHubFeedWeb.js
+++ b/action/messageHubFeedWeb.js
@@ -126,7 +126,7 @@ function main(params) {
                 })
                 .then(triggerDoc => {
                     if (!triggerDoc.status.active) {
-                        resolve(common.webResponse(400, `${params.triggerName} cannot be updated because it is disabled`));
+                        return resolve(common.webResponse(400, `${params.triggerName} cannot be updated because it is disabled`));
                     }
 
                     return db.disableTrigger(triggerDoc)

--- a/action/messageHubFeedWeb.js
+++ b/action/messageHubFeedWeb.js
@@ -128,8 +128,13 @@ function main(params) {
                     if (!triggerDoc.status.active) {
                         resolve(common.webResponse(400, `${params.triggerName} cannot be updated because it is disabled`));
                     }
-                    return common.performUpdateParameterValidation(params, triggerDoc)
-                    .then(updatedParams => db.updateTrigger(triggerDoc, updatedParams))
+
+                    return db.disableTrigger(triggerDoc)
+                    .then(() => db.getTrigger(params.triggerName))
+                    .then(doc => {
+                        return common.performUpdateParameterValidation(params, doc)
+                        .then(updatedParams => db.updateTrigger(doc, updatedParams))
+                    });
                 })
                 .then(() => {
                     console.log('successfully updated the trigger');


### PR DESCRIPTION
If for some reason a trigger is deleted, but the corresponding feed is not, allow a trigger in the same namespace with the same trigger name to be recreated with the existing feed.