### PR TITLE
Use latest Kafka client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM python:2.7.16
 RUN apt-get update && apt-get upgrade -y
 
 # install librdkafka
-ENV LIBRDKAFKA_VERSION 1.2.0
+ENV LIBRDKAFKA_VERSION 1.3.0
 RUN git clone --depth 1 --branch v${LIBRDKAFKA_VERSION} https://github.com/edenhill/librdkafka.git librdkafka \
     && cd librdkafka \
     && ./configure \

--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -295,7 +295,8 @@ class ConsumerProcess (Process):
                         'group.id': self.trigger,
                         'default.topic.config': {'auto.offset.reset': 'latest'},
                         'enable.auto.commit': False,
-                        'api.version.request': True
+                        'api.version.request': True,
+                        'isolation.level': 'read_uncommitted'
                     }
 
             if self.isMessageHub:


### PR DESCRIPTION
Bump Kafka client version from 1.2.0 to 1.3.0. Release notes can be found here: https://github.com/edenhill/librdkafka/releases.

Use `isolation.level` of `read_uncommitted` to restore previous consumer read behavior prior to 1.2.0, ie disable transaction consumer.

