### PR TITLE
Handle cases when authKey does not exist in DB documents

### DIFF
--- a/provider/consumer.py
+++ b/provider/consumer.py
@@ -160,8 +160,12 @@ class ConsumerProcess (Process):
         if 'isIamKey' in params and params['isIamKey'] == True:
             self.authHandler = IAMAuth(params['authKey'], params['iamUrl'])
         else:
-            auth = params['authKey'].split(':')
-            self.authHandler = HTTPBasicAuth(auth[0], auth[1])
+            if 'authKey' in params:
+                auth = params['authKey'].split(':')
+                self.authHandler = HTTPBasicAuth(auth[0], auth[1])
+            else:
+                parsedUrl = urlparse(params["triggerURL"])
+                self.authHandler = HTTPBasicAuth(parsedUrl.username, parsedUrl.password)
 
         # handle the case where there may be existing triggers that do not
         # have the isJSONData field set


### PR DESCRIPTION
Changes were made previously to auth functionality that break old triggers. Related change are here: https://github.com/apache/openwhisk-package-kafka/pull/284/files#diff-e29deed9f02a1fe92d43313f261bc3f2R150. The authKey field was added to the database documents. Triggers that existed in the database previous to this change no longer work.