### PR TITLE
Handle URL params gently

### DIFF
--- a/action/lib/common.js
+++ b/action/lib/common.js
@@ -107,7 +107,7 @@ function massageParamsForWeb(rawParams) {
 function getWebActionURL(endpoint, actionName) {
     var apiHost = addHTTPS(endpoint);
 
-    return `${apiHost}/api/v1/web/whisk.system/messagingWeb/${actionName}.http`;
+    return `${apiHost}/api/v1/web/whisk.system/messagingWeb/${actionName}`;
 }
 
 function createTrigger(endpoint, params, actionName) {

--- a/action/lib/common.js
+++ b/action/lib/common.js
@@ -26,14 +26,21 @@ function triggerComponents(triggerName) {
     };
 }
 
+function addHTTPS(url) {
+    if (!/^(?:f|ht)tps?\:\/\//.test(url)) {
+        url = "https://" + url;
+    }
+    return url;
+}
+
 function getTriggerURL(endpoint, triggerName) {
-    var massagedAPIHost = endpoint.replace(/https?:\/\/(.*)/, "$1");
+    var massagedAPIHost = addHTTPS(endpoint)
 
     var components = triggerComponents(triggerName);
     var namespace = components.namespace;
     var trigger = components.triggerName;
 
-    var url = `https://${massagedAPIHost}/api/v1/namespaces/${encodeURIComponent(namespace)}/triggers/${encodeURIComponent(trigger)}`;
+    var url = `${massagedAPIHost}/api/v1/namespaces/${encodeURIComponent(namespace)}/triggers/${encodeURIComponent(trigger)}`;
 
     return url;
 }
@@ -98,7 +105,9 @@ function massageParamsForWeb(rawParams) {
 }
 
 function getWebActionURL(endpoint, actionName) {
-    return `https://${endpoint}/api/v1/web/whisk.system/messagingWeb/${actionName}.http`;
+    var massagedAPIHost = addHTTPS(endpoint)
+
+    return `${massagedAPIHost}/api/v1/web/whisk.system/messagingWeb/${actionName}.http`;
 }
 
 function createTrigger(endpoint, params, actionName) {

--- a/action/lib/common.js
+++ b/action/lib/common.js
@@ -34,7 +34,7 @@ function addHTTPS(url) {
 }
 
 function getTriggerURL(endpoint, triggerName) {
-    var massagedAPIHost = addHTTPS(endpoint)
+    var massagedAPIHost = addHTTPS(endpoint);
 
     var components = triggerComponents(triggerName);
     var namespace = components.namespace;
@@ -105,7 +105,7 @@ function massageParamsForWeb(rawParams) {
 }
 
 function getWebActionURL(endpoint, actionName) {
-    var massagedAPIHost = addHTTPS(endpoint)
+    var massagedAPIHost = addHTTPS(endpoint);
 
     return `${massagedAPIHost}/api/v1/web/whisk.system/messagingWeb/${actionName}.http`;
 }

--- a/action/lib/common.js
+++ b/action/lib/common.js
@@ -27,20 +27,20 @@ function triggerComponents(triggerName) {
 }
 
 function addHTTPS(url) {
-    if (!/^(?:f|ht)tps?\:\/\//.test(url)) {
+    if (!/^https?\:\/\//.test(url)) {
         url = "https://" + url;
     }
     return url;
 }
 
 function getTriggerURL(endpoint, triggerName) {
-    var massagedAPIHost = addHTTPS(endpoint);
+    var apiHost = addHTTPS(endpoint);
 
     var components = triggerComponents(triggerName);
     var namespace = components.namespace;
     var trigger = components.triggerName;
 
-    var url = `${massagedAPIHost}/api/v1/namespaces/${encodeURIComponent(namespace)}/triggers/${encodeURIComponent(trigger)}`;
+    var url = `${apiHost}/api/v1/namespaces/${encodeURIComponent(namespace)}/triggers/${encodeURIComponent(trigger)}`;
 
     return url;
 }
@@ -105,9 +105,9 @@ function massageParamsForWeb(rawParams) {
 }
 
 function getWebActionURL(endpoint, actionName) {
-    var massagedAPIHost = addHTTPS(endpoint);
+    var apiHost = addHTTPS(endpoint);
 
-    return `${massagedAPIHost}/api/v1/web/whisk.system/messagingWeb/${actionName}.http`;
+    return `${apiHost}/api/v1/web/whisk.system/messagingWeb/${actionName}.http`;
 }
 
 function createTrigger(endpoint, params, actionName) {


### PR DESCRIPTION
Previously url variable has strictly provided "https" protocol,
which totally broke feed if "https" was provided in endpoint variable.
Add new function based on regex to handle both types with or
without protocol.