### PR TITLE
Bump flask to 1.1.4 to fix `is_xhr` deprecated error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ ENV CPLUS_INCLUDE_PATH /usr/local/include
 ENV LIBRARY_PATH /usr/local/lib
 ENV LD_LIBRARY_PATH /usr/local/lib
 
-RUN pip install gevent==1.1.2 flask==0.11.1 confluent-kafka==${LIBRDKAFKA_VERSION} \
+RUN pip install gevent==1.1.2 flask==1.1.4 confluent-kafka==${LIBRDKAFKA_VERSION} \
     requests==2.10.0 cloudant==2.5.0 psutil==5.0.0
 
 # while I expect these will be overridden during deployment, we might as well


### PR DESCRIPTION
https://github.com/pallets/flask/issues/2549

I verified that it works well with flask 1.1.4